### PR TITLE
Hotfix since until params

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,14 @@ version: "2"
 
 services:
 
+  app:
+    build: .
+    tty: true
+    command: bash
+    volumes:
+      - ./:/code
+    working_dir: /code
+
   tests:
     build: .
     image: keboola/sklik-extractor

--- a/src/run.php
+++ b/src/run.php
@@ -56,6 +56,14 @@ try {
 
     $since = isset($config['parameters']['since']) ? $config['parameters']['since'] : '-1 day';
     $until = isset($config['parameters']['until']) ? $config['parameters']['until'] : '-1 day';
+
+    if (trim($since) === '') {
+        $since = '-1 day';
+    }
+    if (trim($until) === '') {
+        $until = '-1 day';
+    }
+
     $startDate = \DateTime::createFromFormat('Y-m-d H:i:s', date('Y-m-d 00:00:01', strtotime($since)));
     $endDate = \DateTime::createFromFormat('Y-m-d H:i:s', date('Y-m-d 00:00:01', strtotime($until)));
     $impressionShare = isset($config['parameters']['impressionShare']) ? $config['parameters']['impressionShare'] : false;

--- a/src/run.php
+++ b/src/run.php
@@ -6,6 +6,7 @@
  */
 
 use Symfony\Component\Yaml\Yaml;
+use Keboola\SklikExtractor\Exception as SklikExtractorException;
 
 ini_set('display_errors', true);
 date_default_timezone_set('Europe/Prague');
@@ -66,6 +67,11 @@ try {
 
     $startDate = \DateTime::createFromFormat('Y-m-d H:i:s', date('Y-m-d 00:00:01', strtotime($since)));
     $endDate = \DateTime::createFromFormat('Y-m-d H:i:s', date('Y-m-d 00:00:01', strtotime($until)));
+
+    if ($startDate->getTimestamp() > $endDate->getTimestamp()) {
+        throw new SklikExtractorException('Invalid "since" or "until" parameter. Parameter "since" cannot be bigger than "until".');
+    }
+
     $impressionShare = isset($config['parameters']['impressionShare']) ? $config['parameters']['impressionShare'] : false;
     $accountId = isset($config['parameters']['accountId']) ? $config['parameters']['accountId'] : false;
 


### PR DESCRIPTION
Fixes #9 

Changes:

- new docker-compose service (for better dev)
- check for empty since/until and default to `-1 day` (as before)
- throw exception if since is bigger than until