### PR TITLE
fix: do not add id to display columns of queries resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The extractor gets list of all accessible accounts if you don't restrict them ex
             - the Extractor allows you to use relative days in [these supported formats](http://php.net/manual/en/datetime.formats.relative.php). 
         - **displayOptions** - Json object of the display options configuration for `createReport` API call.
         - **displayColumns** - Comma separated list of columns to get for `readReport` API call.
-            - Column `id` as identifier of the resource is downloaded every time.
+            - Column `id` as identifier of the resource is downloaded every time (except for resource `queries` which does not support `id`).
     
 ### API Limits
     

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -49,7 +49,7 @@ class Extractor
                 $dateTo = $report['restrictionFilter']['dateTo'] ?? 'today';
                 $report['restrictionFilter']['dateTo'] = date('Y-m-d', strtotime($dateTo));
 
-                if (!in_array('id', $report['displayColumns'])) {
+                if (!in_array('id', $report['displayColumns']) && $report['resource'] !== 'queries') {
                     $report['displayColumns'][] = 'id';
                 }
 


### PR DESCRIPTION
Resoursa `queries` jako jediná nepodporuje `id`, který přidáváme do stahování všech reportů automaticky.