### PR TITLE
do not add id to display columns of queries resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The extractor gets list of all accessible accounts if you don't restrict them ex
             - the Extractor allows you to use relative days in [these supported formats](http://php.net/manual/en/datetime.formats.relative.php). 
         - **displayOptions** - Json object of the display options configuration for `createReport` API call.
         - **displayColumns** - Comma separated list of columns to get for `readReport` API call.
-            - Column `id` as identifier of the resource is downloaded every time.
+            - Column `id` as identifier of the resource is downloaded every time (except for resource `queries` which does not support `id`).
     
 ### API Limits
     

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The extractor gets list of all accessible accounts if you don't restrict them ex
             - the Extractor allows you to use relative days in [these supported formats](http://php.net/manual/en/datetime.formats.relative.php). 
         - **displayOptions** - Json object of the display options configuration for `createReport` API call.
         - **displayColumns** - Comma separated list of columns to get for `readReport` API call.
-            - Column `id` as identifier of the resource is downloaded every time (except for resource `queries` which does not support `id`).
+            - Column `id` as identifier of the resource is downloaded every time (except for resource `queries` which has `query` instead).
     
 ### API Limits
     

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -49,7 +49,7 @@ class Extractor
                 $dateTo = $report['restrictionFilter']['dateTo'] ?? 'today';
                 $report['restrictionFilter']['dateTo'] = date('Y-m-d', strtotime($dateTo));
 
-                if (!in_array('id', $report['displayColumns'])) {
+                if (!in_array('id', $report['displayColumns']) && $report['resource'] !== 'queries') {
                     $report['displayColumns'][] = 'id';
                 }
 

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -48,9 +48,10 @@ class Extractor
                 $report['restrictionFilter']['dateFrom'] = date('Y-m-d', strtotime($dateFrom));
                 $dateTo = $report['restrictionFilter']['dateTo'] ?? 'today';
                 $report['restrictionFilter']['dateTo'] = date('Y-m-d', strtotime($dateTo));
+                $primary = ($report['resource'] === 'queries') ? 'query' : 'id';
 
-                if (!in_array('id', $report['displayColumns']) && $report['resource'] !== 'queries') {
-                    $report['displayColumns'][] = 'id';
+                if (!in_array('id', $report['displayColumns'])) {
+                    $report['displayColumns'][] = $primary;
                 }
 
                 $result = $this->api->createReport(
@@ -78,7 +79,7 @@ class Extractor
                         $limit
                     );
 
-                    $this->userStorage->saveReport($report['name'], $data, $account['userId']);
+                    $this->userStorage->saveReport($report['name'], $data, $account['userId'], $primary);
                     $offset += $limit;
                 } while (count($data) > 0);
             }

--- a/src/UserStorage.php
+++ b/src/UserStorage.php
@@ -66,14 +66,14 @@ class UserStorage
         $file->writeRow($dataToSave);
     }
 
-    public function saveReport(string $name, array $data, int $accountId) : void
+    public function saveReport(string $name, array $data, int $accountId, string $primary = 'id') : void
     {
         if (!count($data)) {
             return;
         }
 
         foreach ($data as $row) {
-            $rowId = $row['id'];
+            $rowId = $row[$primary];
             if (isset($row['stats'])) {
                 // save stats to a separate table
                 foreach ($row['stats'] as $stat) {
@@ -81,10 +81,13 @@ class UserStorage
                         $stat['date'] = null;
                     }
                     ksort($stat);
-                    $save = ['id' => $rowId] + $stat;
+                    $save = [$primary => $rowId] + $stat;
 
                     if (!isset($this->tables["$name-stats"])) {
-                        $this->tables["$name-stats"] = ['columns' => array_keys($save), 'primary' => ['id', 'date']];
+                        $this->tables["$name-stats"] = [
+                            'columns' => array_keys($save),
+                            'primary' => [$primary, 'date'],
+                        ];
                     }
                     $this->save("$name-stats", $save);
                 }
@@ -101,12 +104,12 @@ class UserStorage
                 }
             }
 
-            unset($row['id']);
+            unset($row[$primary]);
             ksort($row);
-            $row = ['id' => $rowId, 'accountId' => $accountId] + $row;
+            $row = [$primary => $rowId, 'accountId' => $accountId] + $row;
 
             if (!isset($this->tables[$name])) {
-                $this->tables[$name] = ['columns' => array_keys($row), 'primary' => ['id']];
+                $this->tables[$name] = ['columns' => array_keys($row), 'primary' => [$primary]];
             }
             $this->save($name, $row);
         }

--- a/tests/phpunit/ExtractorTest.php
+++ b/tests/phpunit/ExtractorTest.php
@@ -51,6 +51,16 @@ class ExtractorTest extends TestCase
                         'displayOptions' => json_encode(['statGranularity' => 'daily']),
                         'displayColumns' => 'name, clicks, impressions, budget.name',
                     ],
+                    [
+                        'name' => 'queries',
+                        'resource' => 'queries',
+                        'restrictionFilter' => json_encode([
+                            'dateFrom' => getenv('SKLIK_DATE_FROM'),
+                            'dateTo' => getenv('SKLIK_DATE_TO'),
+                        ]),
+                        'displayOptions' => json_encode(['statGranularity' => 'daily']),
+                        'displayColumns' => 'query,group.name,keyword.id',
+                    ],
                 ],
             ],
         ], new ConfigDefinition());
@@ -59,11 +69,14 @@ class ExtractorTest extends TestCase
 
         $this->assertFileExists($this->temp->getTmpFolder() . '/accounts.csv');
         $this->assertFileExists($this->temp->getTmpFolder() . '/report1.csv');
+        $this->assertFileExists($this->temp->getTmpFolder() . '/queries.csv');
         $metaFile = file($this->temp->getTmpFolder() . '/report1.csv');
         $this->assertEquals('"id","accountId","budget_name","name"', trim($metaFile[0]));
         $this->assertFileExists($this->temp->getTmpFolder() . '/report1-stats.csv');
         $statsFile = file($this->temp->getTmpFolder() . '/report1-stats.csv');
         $this->assertEquals('"id","clicks","date","impressions"', trim($statsFile[0]));
+        $metaFile = file($this->temp->getTmpFolder() . '/queries.csv');
+        $this->assertEquals('"query","accountId","group_name","keyword_id"', trim($metaFile[0]));
     }
 
     /**


### PR DESCRIPTION
Tak pro velký úspěch ještě jednou. (https://github.com/keboola/sklik-extractor/pull/13 - Resoursa queries jako jediná nepodporuje id, který přidáváme do stahování všech reportů automaticky.) Kvůli ukládání do Storage tam musí něco zůstat jako primární klíč, tak se pro tu resoursu namísto `id` stahuje `query`.