### PR TITLE
catch  missing report field in readReport result as user error

### DIFF
--- a/src/SklikApi.php
+++ b/src/SklikApi.php
@@ -187,7 +187,6 @@ class SklikApi
 
     protected function request(string $method, ?array $args = [], ?int $retries = self::RETRIES_COUNT) : array
     {
-        echo json_encode(['method' => $method, 'args' => $args]).PHP_EOL;
         $decoder = new JsonDecode(true);
         try {
             $response = $this->client->post($method, ['json' => $args]);

--- a/src/SklikApi.php
+++ b/src/SklikApi.php
@@ -180,6 +180,7 @@ class SklikApi
 
     protected function request(string $method, ?array $args = [], ?int $retries = self::RETRIES_COUNT) : array
     {
+        echo json_encode(['method' => $method, 'args' => $args]).PHP_EOL;
         $decoder = new JsonDecode(true);
         try {
             $response = $this->client->post($method, ['json' => $args]);

--- a/src/SklikApi.php
+++ b/src/SklikApi.php
@@ -156,15 +156,22 @@ class SklikApi
         ?int $offset = 0,
         ?int $limit = 100
     ): array {
-        $result = $this->requestAuthenticated("$resource.readReport", [
-            $reportId,
-            [
-                'offset' => $offset,
-                'limit' => $limit,
-                'allowEmptyStatistics' => true,
-                'displayColumns' => $displayColumns,
-            ],
-        ]);
+        $args = [
+            'offset' => $offset,
+            'limit' => $limit,
+            'allowEmptyStatistics' => true,
+            'displayColumns' => $displayColumns,
+        ];
+        $result = $this->requestAuthenticated("$resource.readReport", [$reportId, $args]);
+        if (!isset($result['report'])) {
+            throw Exception::apiError(
+                'Result is missing "report" field.',
+                "$resource.readReport",
+                $args,
+                200,
+                $result
+            );
+        }
         return $result['report'];
     }
 


### PR DESCRIPTION
Ten `report` by měl být povinný field. Udělal jsem z toho teda user error a docela by mě zajímalo co jim to vrátí.