### PR TITLE
Fix default date inputs for reports 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can use API token or Sklik credentials for authorization.
             - `intends.negative`
             - etc.
         - **restrictionFilter** - Json object of the restriction filter configuration for `createReport` API call.
-            - `dateFrom` and `dateTo` are required values. If omitted, yesterday's and today's dates will be used.
+            - `dateFrom` and `dateTo` are required values. If omitted, yesterday's dates will be used.
             - the Extractor allows you to use relative days in [these supported formats](http://php.net/manual/en/datetime.formats.relative.php). 
         - **displayOptions** - Json object of the display options configuration for `createReport` API call.
         - **displayColumns** - Comma separated list of columns to get for `readReport` API call.

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -46,7 +46,7 @@ class Extractor
             foreach ($config->getReports() as $report) {
                 $dateFrom = $report['restrictionFilter']['dateFrom'] ?? '-1 day';
                 $report['restrictionFilter']['dateFrom'] = date('Y-m-d', strtotime($dateFrom));
-                $dateTo = $report['restrictionFilter']['dateTo'] ?? 'today';
+                $dateTo = $report['restrictionFilter']['dateTo'] ?? '-1 day';
                 $report['restrictionFilter']['dateTo'] = date('Y-m-d', strtotime($dateTo));
                 $primary = ($report['resource'] === 'queries') ? 'query' : 'id';
 

--- a/src/SklikApi.php
+++ b/src/SklikApi.php
@@ -7,6 +7,7 @@ namespace Keboola\SklikExtractor;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use Keboola\Component\UserException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
@@ -77,6 +78,17 @@ class SklikApi
     public function getAccounts(): array
     {
         $accounts = $this->requestAuthenticated('client.get');
+        if (!isset($accounts['user'])) {
+            $this->logger->error(
+                'API returned unexpected result to client.get request. It is missing \'user\' information.',
+                [
+                    'method' => 'client.get',
+                    'response' => $accounts,
+                ]
+            );
+            throw new UserException('API returned unexpected result to client.get request. '
+                . 'It is missing \'user\' information.');
+        }
         // Add user itself to check for reports
         array_unshift($accounts['foreignAccounts'], [
             'userId' => $accounts['user']['userId'],

--- a/src/SklikApi.php
+++ b/src/SklikApi.php
@@ -66,6 +66,14 @@ class SklikApi
     {
         $limit = 100;
         $limits = $this->requestAuthenticated('api.limits');
+        if (!isset($limits['batchCallLimits'])) {
+            $message = 'API returned unexpected result to api.limits request. It is missing \'batchCallLimits\'.';
+            $this->logger->error($message, [
+                'method' => 'api.limits',
+                'response' => $limits,
+            ]);
+            throw new UserException($message);
+        }
         foreach ($limits['batchCallLimits'] as $l) {
             if ($l['name'] === 'global.list') {
                 $limit = $l['limit'];
@@ -79,15 +87,12 @@ class SklikApi
     {
         $accounts = $this->requestAuthenticated('client.get');
         if (!isset($accounts['user'])) {
-            $this->logger->error(
-                'API returned unexpected result to client.get request. It is missing \'user\' information.',
-                [
-                    'method' => 'client.get',
-                    'response' => $accounts,
-                ]
-            );
-            throw new UserException('API returned unexpected result to client.get request. '
-                . 'It is missing \'user\' information.');
+            $message = 'API returned unexpected result to client.get request. It is missing \'user\' information.';
+            $this->logger->error($message, [
+                'method' => 'client.get',
+                'response' => $accounts,
+            ]);
+            throw new UserException($message);
         }
         // Add user itself to check for reports
         array_unshift($accounts['foreignAccounts'], [


### PR DESCRIPTION
Navazuje na https://github.com/keboola/sklik-extractor/pull/26 a opravuje:
- defaultní nastavení datumů pro reporty (#24 a #25)
- loguje a korektně failne na chybných odpovědích API (#20 a #22)
- udělá retry na 500 chyby z API (#23) - předtím dělal login + retry jen na 401 chyby, asi jako že kdyby vypršela session, ale myslím že to je nějaká hypotetická situace která spíš nenastane ;o)
