### PR TITLE
fix: put report validation to Config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\SklikExtractor;
 
 use Keboola\Component\Config\BaseConfig;
+use stdClass;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
@@ -52,6 +53,16 @@ class Config extends BaseConfig
             }
             $report['displayColumns'] = strlen($report['displayColumns']) > 0
                 ? array_map('trim', explode(',', $report['displayColumns'])) : [];
+            if (!count($report['displayOptions'])) {
+                $report['displayOptions'] = new stdClass();
+            }
+
+            if (!isset($restrictionFilter['dateFrom'])) {
+                throw new Exception('Setting of dateFrom on restrictionFilter is required');
+            }
+            if (!isset($restrictionFilter['dateTo'])) {
+                throw new Exception('Setting of dateTo on restrictionFilter is required');
+            }
         }
         return $reports;
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,10 +58,10 @@ class Config extends BaseConfig
                 $report['displayOptions'] = new stdClass();
             }
             if (!isset($report['restrictionFilter']['dateFrom'])) {
-                throw new Exception('Setting of dateFrom on restrictionFilter is required');
+                $report['restrictionFilter']['dateFrom'] = '-1 day';
             }
             if (!isset($report['restrictionFilter']['dateTo'])) {
-                throw new Exception('Setting of dateTo on restrictionFilter is required');
+                $report['restrictionFilter']['dateTo'] = '-1 day';
             }
         }
         return $reports;

--- a/src/Config.php
+++ b/src/Config.php
@@ -53,14 +53,14 @@ class Config extends BaseConfig
             }
             $report['displayColumns'] = strlen($report['displayColumns']) > 0
                 ? array_map('trim', explode(',', $report['displayColumns'])) : [];
+
             if (!count($report['displayOptions'])) {
                 $report['displayOptions'] = new stdClass();
             }
-
-            if (!isset($restrictionFilter['dateFrom'])) {
+            if (!isset($report['restrictionFilter']['dateFrom'])) {
                 throw new Exception('Setting of dateFrom on restrictionFilter is required');
             }
-            if (!isset($restrictionFilter['dateTo'])) {
+            if (!isset($report['restrictionFilter']['dateTo'])) {
                 throw new Exception('Setting of dateTo on restrictionFilter is required');
             }
         }

--- a/src/SklikApi.php
+++ b/src/SklikApi.php
@@ -151,16 +151,6 @@ class SklikApi
         ?array $displayOptions = [],
         ?int $userId = null
     ): array {
-        if (!count($displayOptions)) {
-            $displayOptions = new \stdClass();
-        }
-        if (!isset($restrictionFilter['dateFrom'])) {
-            throw new Exception('Setting of dateFrom on restrictionFilter is required');
-        }
-        if (!isset($restrictionFilter['dateTo'])) {
-            throw new Exception('Setting of dateTo on restrictionFilter is required');
-        }
-
         $result = $this->requestAuthenticated(
             "$resource.createReport",
             [$restrictionFilter, $displayOptions],

--- a/tests/functional/DatadirTest.php
+++ b/tests/functional/DatadirTest.php
@@ -23,7 +23,8 @@ class DatadirTest extends AbstractDatadirTestCase
                     [
                         'name' => 'queries',
                         'resource' => 'queries',
-                        'restrictionFilter' => '{"dateFrom":"-1 day","dateTo":"-1 day"}',
+                        'restrictionFilter' => '{"dateFrom":"'.getenv('SKLIK_DATE_FROM')
+                            .'","dateTo":"'.getenv('SKLIK_DATE_TO').'"}',
                         'displayOptions' => '{"statGranularity":"daily"}',
                         'displayColumns' => 'query,campaign.name,impressions,clicks',
                     ],

--- a/tests/phpunit/ExtractorTest.php
+++ b/tests/phpunit/ExtractorTest.php
@@ -121,9 +121,7 @@ class ExtractorTest extends TestCase
 
     public function testConfigInvalidRestrictionFilter(): void
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('todo');
-        new Config([
+        $config = new Config([
             'parameters' => [
                 '#token' => getenv('SKLIK_API_TOKEN'),
                 'accounts' => '123,456',
@@ -132,7 +130,6 @@ class ExtractorTest extends TestCase
                         'name' => 'report1',
                         'resource' => 'campaigns',
                         'restrictionFilter' => json_encode([
-                            'dateFrom' => getenv('SKLIK_DATE_FROM'),
                             'dateTo' => getenv('SKLIK_DATE_TO'),
                         ]),
                         'displayOptions' => json_encode(['statGranularity' => 'daily']),
@@ -141,5 +138,8 @@ class ExtractorTest extends TestCase
                 ],
             ],
         ], new ConfigDefinition());
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Setting of dateFrom on restrictionFilter is required');
+        $config->getReports();
     }
 }

--- a/tests/phpunit/ExtractorTest.php
+++ b/tests/phpunit/ExtractorTest.php
@@ -119,7 +119,7 @@ class ExtractorTest extends TestCase
         $this->assertFileNotExists($this->temp->getTmpFolder() . '/report1-stats.csv');
     }
 
-    public function testConfigInvalidRestrictionFilter(): void
+    public function testConfigIncompleteRestrictionFilter(): void
     {
         $config = new Config([
             'parameters' => [
@@ -138,8 +138,10 @@ class ExtractorTest extends TestCase
                 ],
             ],
         ], new ConfigDefinition());
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Setting of dateFrom on restrictionFilter is required');
-        $config->getReports();
+        $reports =  $config->getReports();
+        $this->assertCount(1, $reports);
+        $this->assertArrayHasKey('restrictionFilter', $reports[0]);
+        $this->assertArrayHasKey('dateFrom', $reports[0]['restrictionFilter']);
+        $this->assertEquals('-1 day', $reports[0]['restrictionFilter']['dateFrom']);
     }
 }

--- a/tests/phpunit/ExtractorTest.php
+++ b/tests/phpunit/ExtractorTest.php
@@ -7,6 +7,7 @@ namespace Keboola\SklikExtractor\Tests;
 use Keboola\Component\Logger;
 use Keboola\SklikExtractor\Config;
 use Keboola\SklikExtractor\ConfigDefinition;
+use Keboola\SklikExtractor\Exception;
 use Keboola\SklikExtractor\Extractor;
 use Keboola\SklikExtractor\SklikApi;
 use Keboola\SklikExtractor\UserStorage;
@@ -116,5 +117,29 @@ class ExtractorTest extends TestCase
         $this->assertFileNotExists($this->temp->getTmpFolder() . '/accounts.csv');
         $this->assertFileNotExists($this->temp->getTmpFolder() . '/report1.csv');
         $this->assertFileNotExists($this->temp->getTmpFolder() . '/report1-stats.csv');
+    }
+
+    public function testConfigInvalidRestrictionFilter(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('todo');
+        new Config([
+            'parameters' => [
+                '#token' => getenv('SKLIK_API_TOKEN'),
+                'accounts' => '123,456',
+                'reports' => [
+                    [
+                        'name' => 'report1',
+                        'resource' => 'campaigns',
+                        'restrictionFilter' => json_encode([
+                            'dateFrom' => getenv('SKLIK_DATE_FROM'),
+                            'dateTo' => getenv('SKLIK_DATE_TO'),
+                        ]),
+                        'displayOptions' => json_encode(['statGranularity' => 'daily']),
+                        'displayColumns' => 'name, clicks, impressions',
+                    ],
+                ],
+            ],
+        ], new ConfigDefinition());
     }
 }


### PR DESCRIPTION
fixes #32 

nefunguje ale `dateFrom and dateTo are required values. If omitted, yesterday's dates will be used.` - nevim jestli to tak fungovat ma (nenasel jsem to nikde v kodu), nebo je to jen chyba dokumentace.
